### PR TITLE
Fix importerror under django1.6

### DIFF
--- a/likes/urls.py
+++ b/likes/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     'likes.views',


### PR DESCRIPTION
django.conf.urls.defaults has been removed, use django.conf.urls instead.