### PR TITLE
Quotes missing around URL name in "likes" template tag (Django 1.5 and later)

### DIFF
--- a/likes/templates/likes/inclusion_tags/likes.html
+++ b/likes/templates/likes/inclusion_tags/likes.html
@@ -9,7 +9,7 @@
         {{ content_obj.vote_total }}
         <span>
             {% if can_vote %}
-                <a class="liker" href="{% url like content_type content_obj.id 1 %}" rel="nofollow">{% trans "I Like" %}</a>
+                <a class="liker" href="{% url 'like' content_type content_obj.id 1 %}" rel="nofollow">{% trans "I Like" %}</a>
             {% else %}
                 {% trans "Likes" %}
             {% endif %}


### PR DESCRIPTION
When using the {% likes object %} template tag, I got this error message:

NoReverseMatch: 'url' requires a non-empty first argument. The syntax changed in Django 1.5, see the docs.

The following post explains why:
http://stackoverflow.com/questions/14882491/django-release-1-5-url-requires-a-non-empty-first-argument-the-syntax-change

Adding quotes around the URL name in likes/templates/likes/inclusion_tags/likes.html solves the problem.