### PR TITLE
django 1.8 doesn't support Model._meta.module_name

### DIFF
--- a/likes/templatetags/likes_inclusion_tags.py
+++ b/likes/templatetags/likes_inclusion_tags.py
@@ -21,7 +21,7 @@ def likes(context, obj, template=None):
         'content_obj': obj,
         'likes_enabled': likes_enabled(obj, request),
         'can_vote': can_vote(obj, request.user, request),
-        'content_type': "-".join((obj._meta.app_label, obj._meta.module_name)),
+        'content_type': "-".join((obj._meta.app_label, obj._meta.model_name)),
         'import_js': import_js
     })
     return context


### PR DESCRIPTION
After this change `django-likes` runs happily under 1.8
