### PR TITLE
Update likes_inclusion_tags.py

### DIFF
--- a/likes/templatetags/likes_inclusion_tags.py
+++ b/likes/templatetags/likes_inclusion_tags.py
@@ -21,7 +21,7 @@ def likes(context, obj, template=None):
         'content_obj': obj,
         'likes_enabled': likes_enabled(obj, request),
         'can_vote': can_vote(obj, request.user, request),
-        'content_type': "-".join((obj._meta.app_label, obj._meta.module_name)),
+        'content_type': "-".join((obj._meta.app_label, obj._meta.model_name)),
         'import_js': import_js
     })
     return context


### PR DESCRIPTION
Django model meta attribute "module_name" will be replaced by "model_name".
Accessing "model._meta.module_name" raises a RemovedInDjango18Warning in Django 1.7.
And in docs https://github.com/jamesturk/django-secretballot Requirements is >=1.8
